### PR TITLE
Updates AzureBlob to support when the blob has a null ContentHash property

### DIFF
--- a/src/Distech.CloudRelay.Common/DAL/AzureBlob.cs
+++ b/src/Distech.CloudRelay.Common/DAL/AzureBlob.cs
@@ -35,7 +35,7 @@ namespace Distech.CloudRelay.Common.DAL
             return new AzureBlob
             {
                 Path = blobPath,
-                Checksum = Convert.ToBase64String(blobProperties.ContentHash),
+                Checksum = Convert.ToBase64String(blobProperties.ContentHash ?? new byte[0]),
                 ContentType = blobProperties.ContentType,
                 LastModified = blobProperties.LastModified,
                 Length = blobProperties.ContentLength,
@@ -54,7 +54,7 @@ namespace Distech.CloudRelay.Common.DAL
             return new AzureBlob
             {
                 Path = blobPath,
-                Checksum = Convert.ToBase64String(item.Properties.ContentHash),
+                Checksum = Convert.ToBase64String(item.Properties.ContentHash ?? new byte[0]),
                 ContentType = item.Properties.ContentType,
                 LastModified = item.Properties.LastModified ?? DateTimeOffset.MinValue,
                 Length = item.Properties.ContentLength ?? -1,

--- a/src/Distech.CloudRelay.Common/DAL/AzureBlob.cs
+++ b/src/Distech.CloudRelay.Common/DAL/AzureBlob.cs
@@ -35,7 +35,7 @@ namespace Distech.CloudRelay.Common.DAL
             return new AzureBlob
             {
                 Path = blobPath,
-                Checksum = Convert.ToBase64String(blobProperties.ContentHash ?? new byte[0]),
+                Checksum = Convert.ToBase64String(blobProperties.ContentHash ?? Array.Empty<byte>()),
                 ContentType = blobProperties.ContentType,
                 LastModified = blobProperties.LastModified,
                 Length = blobProperties.ContentLength,
@@ -54,7 +54,7 @@ namespace Distech.CloudRelay.Common.DAL
             return new AzureBlob
             {
                 Path = blobPath,
-                Checksum = Convert.ToBase64String(item.Properties.ContentHash ?? new byte[0]),
+                Checksum = Convert.ToBase64String(item.Properties.ContentHash ?? Array.Empty<byte>()),
                 ContentType = item.Properties.ContentType,
                 LastModified = item.Properties.LastModified ?? DateTimeOffset.MinValue,
                 Length = item.Properties.ContentLength ?? -1,


### PR DESCRIPTION
Updates AzureBlob.FromBlobProperties and .FromBlobItem to support when the blob has a null ContentHash property.
This is necessary to support older devices that have historically uploaded their blobs without any Content-MD5/ContentHash property and which will not be updated to start doing so. These devices didn't have any problems with uploading their blobs in this way until the .NET 6 conversion, which introduced this Convert.ToBase64String call on the blobProperties.ContentHash, which throws an exception if the ContentHash is null.